### PR TITLE
build(workflow): correct auto update commit message

### DIFF
--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: Update Dependencies
+          commit-message: "build(deps): auto update dependencies"
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: false
           branch: updates-${{ steps.date.outputs.date }}


### PR DESCRIPTION
## Summary by Sourcery

Update the GitHub Actions dependency update workflow to use a conventional commit message and clean up labels

CI:
- Use conventional commit format for auto-update commit messages
- Remove redundant 'automated pr' label from the dependency update workflow