### PR TITLE
feat: add django.contrib.postgres to INSTALLED_APPS

### DIFF
--- a/rhgs/settings/base.py
+++ b/rhgs/settings/base.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sitemaps",
+    "django.contrib.postgres",
     "robots",
     "social",
 ]


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add django.contrib.postgres to INSTALLED_APPS to allow using PostgreSQL-specific Django features such as fields and constraints.