### PR TITLE
chore(pre-commit): auto-sync django target version via cog

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,14 @@ repos:
   rev: 1.30.0
   hooks:
   - id: django-upgrade
+    # [[[cog
+    # import cog, re
+    # with open("requirements.txt") as f:
+    #   m = re.search(r"^django==(\d+\.\d+)", f.read(), re.MULTILINE)
+    #   cog.out(f"args: [--target-version, '{m.group(1)}']")
+    # ]]]
     args: [--target-version, '6.0']
+    # [[[end]]] (sum: aqDRvLvt17)
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.21.2
   hooks:
@@ -57,7 +64,14 @@ repos:
   rev: 1.9.0
   hooks:
   - id: djade
-    args: [--target-version, '5.1']
+    # [[[cog
+    # import cog, re
+    # with open("requirements.txt") as f:
+    #   m = re.search(r"^django==(\d+\.\d+)", f.read(), re.MULTILINE)
+    #   cog.out(f"args: [--target-version, '{m.group(1)}']")
+    # ]]]
+    args: [--target-version, '6.0']
+    # [[[end]]] (sum: aqDRvLvt17)
 - repo: https://github.com/rtts/djhtml
   rev: 3.0.11
   hooks:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PIP_PATH:=$(BINPATH)/pip
 WHEEL_PATH:=$(BINPATH)/wheel
 UV_PATH:=~/.cargo/bin/uv
 PRE_COMMIT_PATH:=$(BINPATH)/pre-commit
-COG_PATH:=$(BINPATH)/cog
+COG_CMD:=$(UV_PATH) tool run --from cogapp cog
 
 COGABLE:=$(shell git ls-files | xargs grep -l "\[\[\[cog")
 PYTHON_FILES:=$(wildcard ./**/*.py ./**/tests/*.py)
@@ -81,9 +81,6 @@ $(PRE_COMMIT_PATH): $(PIP_PATH) $(WHEEL_PATH)
 	python -m pip install pre-commit
 	@touch $@
 
-$(COG_PATH): $(PIP_PATH) $(WHEEL_PATH)
-	python -m pip install cogapp
-	@touch $@
 
 init: .envrc $(UV_PATH) .git .git/hooks/pre-commit requirements.dev.txt ## Initalise a enviroment
 
@@ -116,8 +113,8 @@ upgrade: python
 	@python -m pre_commit autoupdate || true
 	python -m pre_commit run --all-files
 
-cog: $(COG_PATH) $(COGABLE)
-	@cog -rc $(filter-out $<,$^)
+cog: $(UV_PATH) $(COGABLE)
+	@$(COG_CMD) -rc $(filter-out $<,$^)
 
 db.sqlite3: ## Import database from heroku
 	@echo "Importing database"


### PR DESCRIPTION
## Summary by Sourcery

Automate syncing of Django target versions in pre-commit hooks and update the cog generation workflow to run via uv rather than a locally installed cog binary.

Build:
- Configure django-upgrade and djade pre-commit hooks to derive their --target-version from the Django version pinned in requirements.txt using cog code generation blocks.
- Switch Makefile cog target to invoke cog via `uv tool run` instead of managing a separate cog binary installation.